### PR TITLE
skip github actions builds to save executors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ on:
   push:
     branches-ignore:
       - master
+      - dev
+      - release
       - pr/*
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Currently, every time the mirror job runs we end up running GitHub actions builds on all platforms for every commit on both `dev` and `release` which ends up burning through our allowance. This PR adds the `branches-ignore` flag to both branches as we know the code is safe from master.