### PR TITLE
Comparable vendor string padding

### DIFF
--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -108,7 +108,18 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
        and 'java.vm.vendor' system properties.],
     DEFAULT_DESC: [from branding.conf],
     CHECK_VALUE: [UTIL_CHECK_STRING_NON_EMPTY_PRINTABLE])
+
+  # Squash multiple spaces now to get length correct, since they will be later anyway
+  COMPANY_NAME=$(echo $COMPANY_NAME | $TR -s " ")
+
+  # Create padded name to 64 bytes (63 char+\0) for comparable builds
+  VENDOR_NAME_LEN=${#COMPANY_NAME}
+  # sequence(vendor length to 62)*\000 = nul padding to 63 chars
+  COMPANY_NAME_PADDING=$($PRINTF "\\\\000%.0s" $(seq $VENDOR_NAME_LEN 62))
+  COMPANY_NAME_PADDED=${COMPANY_NAME}${COMPANY_NAME_PADDING}
+
   AC_SUBST(COMPANY_NAME)
+  AC_SUBST(COMPANY_NAME_PADDED)
 
   # The vendor URL, if any
   # Only set VENDOR_URL if '--with-vendor-url' was used and is not empty.

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -192,6 +192,7 @@ PRODUCT_SUFFIX:=@PRODUCT_SUFFIX@
 JDK_RC_PLATFORM_NAME:=@JDK_RC_PLATFORM_NAME@
 JDK_RC_NAME:=@JDK_RC_NAME@
 COMPANY_NAME:=@COMPANY_NAME@
+COMPANY_NAME_PADDED:=@COMPANY_NAME_PADDED@
 HOTSPOT_VM_DISTRO:=@HOTSPOT_VM_DISTRO@
 MACOSX_BUNDLE_NAME_BASE=@MACOSX_BUNDLE_NAME_BASE@
 MACOSX_BUNDLE_ID_BASE=@MACOSX_BUNDLE_ID_BASE@
@@ -280,7 +281,8 @@ ifneq ($(COMPANY_NAME),)
   # VersionProps.java.template in the jdk for "java.vendor" and
   # vm_version.cpp in the VM for "java.vm.vendor")
   ifneq ($(COMPANY_NAME), N/A)
-    VERSION_CFLAGS += -DVENDOR='"$(COMPANY_NAME)"'
+    # Use padded definition so abstract_vm_version.cpp object is comparable
+    VERSION_CFLAGS += -DVENDOR='"$(COMPANY_NAME_PADDED)"'
   endif
 endif
 

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -121,7 +121,8 @@ const char* Abstract_VM_Version::vm_vendor() {
 #ifdef VENDOR
   return VENDOR;
 #else
-  return "Oracle Corporation";
+  // vm_vendor const char is padded to 64 bytes(63chars+\0) so C object is "comparable"
+  return "Oracle Corporation\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000";
 #endif
 }
 


### PR DESCRIPTION
libjvm.so/jvm.dll is non-comparable by varying Vendor strings due to the following:
 
abstract_vm_version.cpp has two C const values that depend on vendor branded strings:
- VENDOR => vm_vendor : https://github.com/adoptium/jdk/blob/5763be726700be322de3bbaf345d80e11936b472/src/hotspot/share/runtime/abstract_vm_version.cpp#L122
- HOTSPOT_BUILD_USER, part of internal_vm_info_string : https://github.com/adoptium/jdk/blob/5763be726700be322de3bbaf345d80e11936b472/src/hotspot/share/runtime/abstract_vm_version.cpp#L270

1) HOTSPOT_BUILD_USER is actually just derived from the "username" of the build machine, or configure arg --with-build-user. Padding the internal_vm_info_string is tricky, as would require substantial changes to the interface and callers. However, Temurin now builds with "--with-build-user=admin", other vendors can use the same arbitrary "admin" value.
2) vm_vendor is derived from the Vendor name (==CompanyName). The C compiled object const can be padded with "\0" to a desirable padded length (64 bytes chosen). This PR provides changes to automatically pad the Vendor name C const in the compiled object.

Padding a C compiler -DVENDOR='String.....\000\000\000' with octal value of 0x00, which then gets referenced as a C const char string, generates a 0x00 padded value in the compiled object.
 